### PR TITLE
PR creation avoidance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,5 @@ jobs:
       - run: npm install
 
       - run: npm test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.js
+++ b/action.js
@@ -19,9 +19,9 @@ async function run() {
     let repoOwner = github.context.repo.owner
     let repoName = github.context.repo.repo
     const branchName = "go-upgrade-" + latestGoVersion
-    const branchAlreadyExist = branchWithNameAlreadyExist(
-      branchName, 
+    const branchAlreadyExist = await branchWithNameAlreadyExist(
       githubToken,
+      branchName, 
       repoOwner,
       repoName
     )
@@ -31,7 +31,13 @@ async function run() {
     }
 
     core.info('Will create a PR')
-    let prUrl = createPullRequest()
+    let prUrl = await createPullRequest(
+      githubToken,
+      branchName,
+      repoOwner,
+      repoName,
+      latestGoVersion
+    )
     core.info('PR created. Check it out at ' + prUrl);
 }
   
@@ -66,7 +72,7 @@ async function detectGitChanges() {
     return gitChanges != undefined || gitChanges != ""
 }
 
-async function branchWithNameAlreadyExist(branchName, githubToken, repoOwner, repoName) {
+async function branchWithNameAlreadyExist(githubToken, branchName, repoOwner, repoName) {
   let listBranchesResponse = github.getOctokit(githubToken).rest.repos.listBranches({
     owner: repoOwner,
     repo: repoName,
@@ -78,7 +84,7 @@ async function branchWithNameAlreadyExist(branchName, githubToken, repoOwner, re
   return brancheWithName != undefined
 }
 
-async function createPullRequest(branchName, latestGoVersion, repoOwner, repoName) {
+async function createPullRequest(githubToken, branchName, repoOwner, repoName, latestGoVersion) {
   await exec.exec("git config user.name 'github-actions[bot]'");
   await exec.exec("git config user.email 'github-actions[bot]@users.noreply.github.com'");
   await exec.exec("git checkout -b " + branchName);

--- a/action.js
+++ b/action.js
@@ -3,41 +3,36 @@ const github = require('@actions/github');
 const exec = require('@actions/exec');
 
 async function run() {
-    core.info('Get current (latest) installed Go version');
+    core.info('Get current (latest(?)) installed Go version from host');
     const latestGoVersion = await getGoVersion()
   
     core.info('Try to update the "go.mod" file with Go version ' + latestGoVersion);
     updateGoVersion(latestGoVersion)
   
     const changes = detectGitChanges()
-    if (changes) {
-      core.info('Changes detected. Will create a PR')
-  
-      await exec.exec("git config user.name 'github-actions[bot]'");
-      await exec.exec("git config user.email 'github-actions[bot]@users.noreply.github.com'");
-      await exec.exec("git checkout -b go-upgrade-" + latestGoVersion);
-      await exec.exec(`git commit -m "Upgrade Go to version to ` + latestGoVersion + `" .`);
-      await exec.exec("git push origin go-upgrade-" + latestGoVersion);
-  
-      let title = "Upgrade Go version to " + latestGoVersion
-      let head = "go-upgrade-" + latestGoVersion
-      let baseBranch = core.getInput("base-branch")
-  
-      let token = process.env.GITHUB_TOKEN
-      let pullCreateResponse = github.getOctokit(token).rest.pulls.create({
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        title: title,
-        body: "",
-        head: head,
-        base: baseBranch
-      });
-      let prUrl = (await pullCreateResponse).data.html_url
-  
-      core.info('PR created. Check it out at ' + prUrl);
-    } else {
-      core.info('Seems everything is up to date 🎉');
+    if (!changes) {
+      core.info('No changes detect.\nSeems everything is up to date 🎉');
+      return
     }
+
+    let githubToken = process.env.GITHUB_TOKEN
+    let repoOwner = github.context.repo.owner
+    let repoName = github.context.repo.repo
+    const branchName = "go-upgrade-" + latestGoVersion
+    const branchAlreadyExist = branchWithNameAlreadyExist(
+      branchName, 
+      githubToken,
+      repoOwner,
+      repoName
+    )
+    if (branchAlreadyExist) {
+      core.info('Branch with name ' + branchName + ' already exist.\nSeems everything is up to date 🎉');
+      return
+    }
+
+    core.info('Will create a PR')
+    let prUrl = createPullRequest()
+    core.info('PR created. Check it out at ' + prUrl);
 }
   
 async function getGoVersion() {
@@ -71,9 +66,42 @@ async function detectGitChanges() {
     return gitChanges != undefined || gitChanges != ""
 }
 
+async function branchWithNameAlreadyExist(branchName, githubToken, repoOwner, repoName) {
+  let listBranchesResponse = github.getOctokit(githubToken).rest.repos.listBranches({
+    owner: repoOwner,
+    repo: repoName,
+  })
+  let brancheWithName = (await listBranchesResponse).data.find(item => {
+    return item.name == branchName
+  })
+
+  return brancheWithName != undefined
+}
+
+async function createPullRequest(branchName, latestGoVersion, repoOwner, repoName) {
+  await exec.exec("git config user.name 'github-actions[bot]'");
+  await exec.exec("git config user.email 'github-actions[bot]@users.noreply.github.com'");
+  await exec.exec("git checkout -b " + branchName);
+  await exec.exec(`git commit -m "Upgrade Go to version to ` + latestGoVersion + `" .`);
+  await exec.exec("git push origin " + branchName);
+
+  let title = "Upgrade Go version to " + latestGoVersion
+  let baseBranch = core.getInput("base-branch")
+
+  let pullCreateResponse = github.getOctokit(githubToken).rest.pulls.create({
+    owner: repoOwner,
+    repo: repoName,
+    title: title,
+    body: "",
+    head: branchName,
+    base: baseBranch
+  });
+
+  return (await pullCreateResponse).data.html_url
+}
+
 module.exports = {
     run,
     getGoVersion,
-    updateGoVersion,
-    detectGitChanges
+    branchWithNameAlreadyExist
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -25,9 +25,9 @@ async function run() {
     let repoOwner = github.context.repo.owner
     let repoName = github.context.repo.repo
     const branchName = "go-upgrade-" + latestGoVersion
-    const branchAlreadyExist = branchWithNameAlreadyExist(
-      branchName, 
+    const branchAlreadyExist = await branchWithNameAlreadyExist(
       githubToken,
+      branchName, 
       repoOwner,
       repoName
     )
@@ -37,7 +37,13 @@ async function run() {
     }
 
     core.info('Will create a PR')
-    let prUrl = createPullRequest()
+    let prUrl = await createPullRequest(
+      githubToken,
+      branchName,
+      repoOwner,
+      repoName,
+      latestGoVersion
+    )
     core.info('PR created. Check it out at ' + prUrl);
 }
   
@@ -72,7 +78,7 @@ async function detectGitChanges() {
     return gitChanges != undefined || gitChanges != ""
 }
 
-async function branchWithNameAlreadyExist(branchName, githubToken, repoOwner, repoName) {
+async function branchWithNameAlreadyExist(githubToken, branchName, repoOwner, repoName) {
   let listBranchesResponse = github.getOctokit(githubToken).rest.repos.listBranches({
     owner: repoOwner,
     repo: repoName,
@@ -84,7 +90,7 @@ async function branchWithNameAlreadyExist(branchName, githubToken, repoOwner, re
   return brancheWithName != undefined
 }
 
-async function createPullRequest(branchName, latestGoVersion, repoOwner, repoName) {
+async function createPullRequest(githubToken, branchName, repoOwner, repoName, latestGoVersion) {
   await exec.exec("git config user.name 'github-actions[bot]'");
   await exec.exec("git config user.email 'github-actions[bot]@users.noreply.github.com'");
   await exec.exec("git checkout -b " + branchName);

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,41 +9,36 @@ const github = __nccwpck_require__(2835);
 const exec = __nccwpck_require__(3409);
 
 async function run() {
-    core.info('Get current (latest) installed Go version');
+    core.info('Get current (latest(?)) installed Go version from host');
     const latestGoVersion = await getGoVersion()
   
     core.info('Try to update the "go.mod" file with Go version ' + latestGoVersion);
     updateGoVersion(latestGoVersion)
   
     const changes = detectGitChanges()
-    if (changes) {
-      core.info('Changes detected. Will create a PR')
-  
-      await exec.exec("git config user.name 'github-actions[bot]'");
-      await exec.exec("git config user.email 'github-actions[bot]@users.noreply.github.com'");
-      await exec.exec("git checkout -b go-upgrade-" + latestGoVersion);
-      await exec.exec(`git commit -m "Upgrade Go to version to ` + latestGoVersion + `" .`);
-      await exec.exec("git push origin go-upgrade-" + latestGoVersion);
-  
-      let title = "Upgrade Go version to " + latestGoVersion
-      let head = "go-upgrade-" + latestGoVersion
-      let baseBranch = core.getInput("base-branch")
-  
-      let token = process.env.GITHUB_TOKEN
-      let pullCreateResponse = github.getOctokit(token).rest.pulls.create({
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        title: title,
-        body: "",
-        head: head,
-        base: baseBranch
-      });
-      let prUrl = (await pullCreateResponse).data.html_url
-  
-      core.info('PR created. Check it out at ' + prUrl);
-    } else {
-      core.info('Seems everything is up to date 🎉');
+    if (!changes) {
+      core.info('No changes detect.\nSeems everything is up to date 🎉');
+      return
     }
+
+    let githubToken = process.env.GITHUB_TOKEN
+    let repoOwner = github.context.repo.owner
+    let repoName = github.context.repo.repo
+    const branchName = "go-upgrade-" + latestGoVersion
+    const branchAlreadyExist = branchWithNameAlreadyExist(
+      branchName, 
+      githubToken,
+      repoOwner,
+      repoName
+    )
+    if (branchAlreadyExist) {
+      core.info('Branch with name ' + branchName + ' already exist.\nSeems everything is up to date 🎉');
+      return
+    }
+
+    core.info('Will create a PR')
+    let prUrl = createPullRequest()
+    core.info('PR created. Check it out at ' + prUrl);
 }
   
 async function getGoVersion() {
@@ -77,11 +72,44 @@ async function detectGitChanges() {
     return gitChanges != undefined || gitChanges != ""
 }
 
+async function branchWithNameAlreadyExist(branchName, githubToken, repoOwner, repoName) {
+  let listBranchesResponse = github.getOctokit(githubToken).rest.repos.listBranches({
+    owner: repoOwner,
+    repo: repoName,
+  })
+  let brancheWithName = (await listBranchesResponse).data.find(item => {
+    return item.name == branchName
+  })
+
+  return brancheWithName != undefined
+}
+
+async function createPullRequest(branchName, latestGoVersion, repoOwner, repoName) {
+  await exec.exec("git config user.name 'github-actions[bot]'");
+  await exec.exec("git config user.email 'github-actions[bot]@users.noreply.github.com'");
+  await exec.exec("git checkout -b " + branchName);
+  await exec.exec(`git commit -m "Upgrade Go to version to ` + latestGoVersion + `" .`);
+  await exec.exec("git push origin " + branchName);
+
+  let title = "Upgrade Go version to " + latestGoVersion
+  let baseBranch = core.getInput("base-branch")
+
+  let pullCreateResponse = github.getOctokit(githubToken).rest.pulls.create({
+    owner: repoOwner,
+    repo: repoName,
+    title: title,
+    body: "",
+    head: branchName,
+    base: baseBranch
+  });
+
+  return (await pullCreateResponse).data.html_url
+}
+
 module.exports = {
     run,
     getGoVersion,
-    updateGoVersion,
-    detectGitChanges
+    branchWithNameAlreadyExist
 }
 
 /***/ }),

--- a/test/actionSpec.js
+++ b/test/actionSpec.js
@@ -1,4 +1,4 @@
-const { getGoVersion } = require('../action.js');
+const { getGoVersion, branchWithNameAlreadyExist } = require('../action.js');
 const assert = require('assert');
 
 describe('Action', function () {
@@ -7,5 +7,29 @@ describe('Action', function () {
       const goVersion = await getGoVersion()
       assert.equal(goVersion, "1.21")
     });
+  });
+
+  describe('#branchWithNameAlreadyExist()', function () {
+    it('should return false because branch does not exist', async function () {
+      let token = process.env.GITHUB_TOKEN
+      const exist = await branchWithNameAlreadyExist(
+        "branchWillNeverExists!Hopefully", 
+        token,
+        "StefMa",
+        "Upgrade-Go-Action"
+      )
+      assert.equal(exist, false)
+    });
+  });
+
+  it('should return true because main branch exist', async function () {
+    let token = process.env.GITHUB_TOKEN
+    const exist = await branchWithNameAlreadyExist(
+      "main", 
+      token,
+      "StefMa",
+      "Upgrade-Go-Action"
+    )
+    assert.equal(exist, true)
   });
 });

--- a/test/actionSpec.js
+++ b/test/actionSpec.js
@@ -13,8 +13,8 @@ describe('Action', function () {
     it('should return false because branch does not exist', async function () {
       let token = process.env.GITHUB_TOKEN
       const exist = await branchWithNameAlreadyExist(
-        "branchWillNeverExists!Hopefully", 
         token,
+        "branchWillNeverExists!Hopefully", 
         "StefMa",
         "Upgrade-Go-Action"
       )
@@ -25,8 +25,8 @@ describe('Action', function () {
   it('should return true because main branch exist', async function () {
     let token = process.env.GITHUB_TOKEN
     const exist = await branchWithNameAlreadyExist(
-      "main", 
       token,
+      "main", 
       "StefMa",
       "Upgrade-Go-Action"
     )


### PR DESCRIPTION
Fixes #1 

For now we just check the branch name. I guess (hope) this is unique enough 🙃 
In case the PR was closed but the branch didn't, we don't do anything.
Assuming here that the user wants to ignore the update.